### PR TITLE
made git token optional and change secret config type to opaque

### DIFF
--- a/tensorflow-build-dc.json
+++ b/tensorflow-build-dc.json
@@ -313,7 +313,7 @@
                 "appName": "${APPLICATION_NAME}"
             }
           },
-          "type": "kubernetes.io/ssh-auth",
+          "type": "Opaque",
           "stringData": {
             "ssh-privatekey": "${PAGURE_SSH_PRIVATE_KEY}",
             "git-token": "${GIT_TOKEN}"
@@ -542,7 +542,7 @@
             "name": "GIT_TOKEN",
             "description": "GIT_TOKEN",
             "value": "",
-            "required": true
+            "required": false
         },
         {
             "name": "GIT_RELEASE_REPO",

--- a/tensorflow-build-job.json
+++ b/tensorflow-build-job.json
@@ -225,7 +225,7 @@
                 "appName": "${APPLICATION_NAME}"
             }
           },
-          "type": "kubernetes.io/ssh-auth",
+          "type": "Opaque",
           "stringData": {
             "ssh-privatekey": "${PAGURE_SSH_PRIVATE_KEY}",
             "git-token": "${GIT_TOKEN}"
@@ -430,7 +430,7 @@
             "name": "GIT_TOKEN",
             "description": "GIT_TOKEN",
             "value": "",
-            "required": true
+            "required": false
         },
         {
             "name": "GIT_RELEASE_REPO",

--- a/tensorflow-build.json
+++ b/tensorflow-build.json
@@ -533,7 +533,7 @@
             "name": "GIT_TOKEN",
             "description": "GIT_TOKEN",
             "value": "",
-            "required": true
+            "required": false
         },
         {
             "name": "GIT_RELEASE_REPO",


### PR DESCRIPTION
Modified the secret config type to Opaque as the type=kub/ssh-auth provides validation but returns an error if not found an ssh key.  When we don't provide ssh-key as while trying to do git release. 
With type=opaque we will no get an error as we are providing Git token.

Made git token optional, as we don't need to provide git token while pushing the wheel files to pagure.