### PR TITLE
functionality to both release and commit wheel files

### DIFF
--- a/build_tools/pagure_commit.sh
+++ b/build_tools/pagure_commit.sh
@@ -1,27 +1,16 @@
 #!/bin/sh
-GIT_COMMIT_MSG="$1"
-FILES="$2"
-WHFLL="$3"
+TENSORFLOW_BUILD_DIR_NAME="$1"
+GIT_COMMIT_MSG="$2"
+FILES="$3"
+WHFLL="$4"
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
-# Naming the directory according to the naming convention
-for varname in ${!TF_NEED_*}; do
-    if [ "${!varname}" = "1" ]; then
-        WORD=$(echo "${varname//TF_NEED_}" | tr '[:upper:]' '[:lower:]')
-        if [ "$varname" = "TF_NEED_CUDA" ]; then
-                WORD+=$TF_CUDA_VERSION
-        fi
-        FINAL_STR+=$WORD"+"
-    fi
-done
-TENSORFLOW_BUILD_DIR_NAME=$OSVER/${TF_GIT_BRANCH//r}/${FINAL_STR::-1}
-
-echo "=============================="
-echo "TENSORFLOW_BUILD_DIR_NAME="$TENSORFLOW_BUILD_DIR_NAME
-echo "NOTES="$GIT_COMMIT_MSG
-echo "FILES="$FILES
-echo "BRANCH="$BRANCH
-echo "=============================="
+# echo "=============================="
+# echo "TENSORFLOW_BUILD_DIR_NAME="$TENSORFLOW_BUILD_DIR_NAME
+# echo "NOTES="$GIT_COMMIT_MSG
+# echo "FILES="$FILES
+# echo "BRANCH="$BRANCH
+# echo "=============================="
 
 
 # Config: Script commit files on behalf of

--- a/s2i/bin/run
+++ b/s2i/bin/run
@@ -449,10 +449,12 @@ else
 							cd tensorflow
 							source ../pagure_commit.sh "${TENSORFLOW_BUILD_DIR_NAME}" "${NOTES}" "${FILES}" "${whlff}"
 						elif [[ "$USE_BOTH" == "1" ]]; then
-							(git clone $PAGURE_COMMIT_REPO;
-							cd tensorflow;
-							source ../pagure_commit.sh "${TENSORFLOW_BUILD_DIR_NAME}" "${NOTES}" "${FILES}" "${whlff}";) & (git clone $GIT_RELEASE_REPO;
-							cd wheels;
+							git clone $PAGURE_COMMIT_REPO
+							cd tensorflow
+							source ../pagure_commit.sh "${TENSORFLOW_BUILD_DIR_NAME}" "${NOTES}" "${FILES}" "${whlff}"
+							cd ..
+							git clone $GIT_RELEASE_REPO
+							cd wheels
 							source ../release.sh "${GIT_TAG}" "${TENSORFLOW_BUILD_DIR_NAME}" "${NOTES}" "${GIT_TOKEN}" "${FILES}")
 						else
 							git clone $GIT_RELEASE_REPO

--- a/s2i/bin/run
+++ b/s2i/bin/run
@@ -56,6 +56,7 @@ echo "TEST_WHEEL_FILE = "$TEST_WHEEL_FILE
 echo "GIT_RELEASE_REPO = "$GIT_RELEASE_REPO
 echo "PAGURE_COMMIT_REPO = "$PAGURE_COMMIT_REPO
 echo "USE_PAGURE_COMMIT ="$USE_PAGURE_COMMIT
+echo "USE_BOTH ="$USE_BOTH
 echo "============================================"
 
 TEST_CMD="import tensorflow as tf ; a = tf.constant([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], shape=[2, 3], name='a') ; \
@@ -78,7 +79,7 @@ echo "which_pip_version="`pip --version `
 echo "which_pip_site="`pip --version |awk '{print $4}' `
 echo "link_which_pip="`ls -l $(which pip) | awk '{print  $9 $10 $11}'`
 
-
+# Naming the directory according to the naming convention
 OSVER=$(. /etc/os-release;echo $ID$VERSION_ID)
 for varname in ${!TF_NEED_*}; do
     if [ "${!varname}" = "1" ]; then
@@ -443,10 +444,16 @@ else
 						GIT_TOKEN="${GIT_TOKEN}"
 						FILES="../${whlff} ../build_info.yaml"
 						ls -l
-						if [ "$USE_PAGURE_COMMIT" == "1" ]; then
+						if [[ "$USE_PAGURE_COMMIT" == "1" ]]; then
 							git clone $PAGURE_COMMIT_REPO
 							cd tensorflow
-							source ../pagure_commit.sh "${NOTES}" "${FILES}" "${whlff}"
+							source ../pagure_commit.sh "${TENSORFLOW_BUILD_DIR_NAME}" "${NOTES}" "${FILES}" "${whlff}"
+						elif [[ "$USE_BOTH" == "1" ]]; then
+							(git clone $PAGURE_COMMIT_REPO;
+							cd tensorflow;
+							source ../pagure_commit.sh "${TENSORFLOW_BUILD_DIR_NAME}" "${NOTES}" "${FILES}" "${whlff}";) & (git clone $GIT_RELEASE_REPO;
+							cd wheels;
+							source ../release.sh "${GIT_TAG}" "${TENSORFLOW_BUILD_DIR_NAME}" "${NOTES}" "${GIT_TOKEN}" "${FILES}")
 						else
 							git clone $GIT_RELEASE_REPO
 							cd wheels

--- a/tensorflow-build-dc.json
+++ b/tensorflow-build-dc.json
@@ -195,11 +195,15 @@
                                     },
                                     {
                                         "name": "PAGURE_COMMIT_REPO",
-                                        "value": "$PAGURE_COMMIT_REPO}"
+                                        "value": "${PAGURE_COMMIT_REPO}"
                                     },
                                     {
                                         "name": "USE_PAGURE_COMMIT",
                                         "value": "${USE_PAGURE_COMMIT}"
+                                    },
+                                    {
+                                        "name": "USE_BOTH",
+                                        "value": "${USE_BOTH}"
                                     },
                                     {
                                         "name": "GIT_TOKEN",
@@ -565,6 +569,12 @@
         {
             "name": "USE_PAGURE_COMMIT",
             "description": "To Push wheel files to pagure tensorflow repository",
+            "required": true,
+            "value": "0"
+        },
+        {
+            "name": "USE_BOTH",
+            "description": "Push wheel files to Pagure tensorflow repository and Release on AICoE Wheels repository",
             "required": true,
             "value": "0"
         }

--- a/tensorflow-build-job.json
+++ b/tensorflow-build-job.json
@@ -165,6 +165,10 @@
                                         "value": "${USE_PAGURE_COMMIT}"
                                     },
                                     {
+                                        "name": "USE_BOTH",
+                                        "value": "${USE_BOTH}"
+                                    },
+                                    {
                                         "name": "GIT_TOKEN",
                                         "valueFrom": {
                                           "secretKeyRef": {
@@ -455,7 +459,12 @@
             "description": "To Push wheel files to pagure tensorflow repository",
             "required": true,
             "value": "0"
-
+        },
+        {
+            "name": "USE_BOTH",
+            "description": "Push wheel files to Pagure tensorflow repository and Release on AICoE Wheels repository",
+            "required": true,
+            "value": "0"
         }
     ]
 }


### PR DESCRIPTION
The functionality works as two background process; one runs GitHub release and one runs Pagure commit.
When USE_BOTH is set 1.