### PR TITLE
Use a parameter for final image to respect OS user for image build

### DIFF
--- a/cuda/cuda-build-chain.json
+++ b/cuda/cuda-build-chain.json
@@ -29,7 +29,7 @@
             "kind": "ImageStream",
             "apiVersion": "v1",
             "metadata": {
-                "name": "python-36-rhel7",
+                "name": "${APPLICATION_NAME_6}",
                 "labels": {
                     "appTypes": "cuda-build-chain",
                     "appName": "${APPLICATION_NAME}"
@@ -400,7 +400,7 @@
                 "output": {
                     "to": {
                         "kind": "ImageStreamTag",
-                        "name": "python-36-rhel7:${APPLICATION_NAME_5}"
+                        "name": "${APPLICATION_NAME_6}:${APPLICATION_NAME_5}"
                     }
                 },
                 "resources": {


### PR DESCRIPTION
Currently the final image name is always `python-36-rhel7`. That means the name would not match change of `OS_VERSION` (as described in README) or change of `S2I_PYTHON_VERSION`.

